### PR TITLE
Fix libpsql regression test for Postgres 12+

### DIFF
--- a/libpsql/README.md
+++ b/libpsql/README.md
@@ -2,6 +2,7 @@
 # PSQL extension for HEALPix
 
 This PSQL extension installs HEALPix functions in a PostgreSQL database.
+It has been successfully tested with Postgres 10 to 15 (included).
 
 ## Available functions
 

--- a/libpsql/expected/simpletests.out
+++ b/libpsql/expected/simpletests.out
@@ -98,10 +98,10 @@ SELECT hpx_center(0, 4);            -- expected: {0,0}
  {0,0}
 (1 row)
 
-SELECT hpx_center(15, 10737418240); -- expected: {225,-89.9985723325173}
-       hpx_center        
--------------------------
- {225,-89.9985723325173}
+SELECT (hpx_center(15, 10737418240))[1] AS center_ra, round((hpx_center(15, 10737418240))[2]::numeric, 13) AS center_dec;    -- expected: 225 | -89.9985723325173
+ center_ra |    center_dec     
+-----------+-------------------
+       225 | -89.9985723325173
 (1 row)
 
 SELECT hpx_center(NULL, 4);         -- expected: NULL

--- a/libpsql/sql/simpletests.sql
+++ b/libpsql/sql/simpletests.sql
@@ -30,7 +30,7 @@ SELECT hpx_hash(0, 0, '-Infinity'::float8); -- expected: ERROR!
 -- TEST HXP_CENTER
 
 SELECT hpx_center(0, 4);            -- expected: {0,0}
-SELECT hpx_center(15, 10737418240); -- expected: {225,-89.9985723325173}
+SELECT (hpx_center(15, 10737418240))[1] AS center_ra, round((hpx_center(15, 10737418240))[2]::numeric, 13) AS center_dec;    -- expected: 225 | -89.9985723325173
 SELECT hpx_center(NULL, 4);         -- expected: NULL
 SELECT hpx_center(0, NULL);         -- expected: NULL
 SELECT hpx_center(30, 4);           -- expected: ERROR!


### PR DESCRIPTION
Among the regression tests for the Postgres extension of cds-healpix-rust (called "pg_cds_healpix"), there is one test whose result precision is different since version 12 included.

Until Postgres 11:

```
SELECT hpx_center(15, 10737418240);
       hpx_center
--------------------------
 {225,-89.9985723325173}
```

But from Postgres 12 (until 15 included):

```
SELECT hpx_center(15, 10737418240);
        hpx_center
--------------------------
 {225,-89.99857233251726}
```

This Pull Request fixes this issue by rounding the declination to 13 decimals (i.e. number of decimals returned in Postgres 10 and 11), only when checking test result.