### PR TITLE
compute neighbours within a discrete ring

### DIFF
--- a/src/nested/mod.rs
+++ b/src/nested/mod.rs
@@ -1637,7 +1637,7 @@ impl Layer {
   pub fn neighbours_in_kth_ring(&self, hash: u64, k: u32) -> Vec<u64> {
     match k {
       0 => [hash; 1].to_vec(),
-      1 => self.neighbours(hash, true).values_vec(),
+      1 => self.neighbours(hash, false).values_vec(),
       k if k <= self.nside => {
         let HashParts { d0h, i, j } = self.decode_hash(hash);
         let mut result = Vec::with_capacity(((k << 1) as usize) << 2);

--- a/src/nested/mod.rs
+++ b/src/nested/mod.rs
@@ -1680,7 +1680,7 @@ impl Layer {
         };
         let mut result = Vec::with_capacity(capacity);
         result.push(hash);
-        for r in 1..(k + 1) {
+        for r in 1..=k {
           self.neighbours_in_kth_ring_internal(d0h, i, j, r, &mut result);
         }
 

--- a/src/nested/mod.rs
+++ b/src/nested/mod.rs
@@ -1638,7 +1638,7 @@ impl Layer {
     match k {
       0 => [hash; 1].to_vec(),
       1 => self.neighbours(hash, true).values_vec(),
-      k if k < self.nside => {
+      k if k <= self.nside => {
         let HashParts { d0h, i, j } = self.decode_hash(hash);
         let mut result = Vec::with_capacity(((k << 1) as usize) << 2);
         self.neighbours_in_kth_ring_internal(d0h, i, j, k, &mut result);
@@ -1671,7 +1671,7 @@ impl Layer {
   pub fn neighbours_disk(&self, hash: u64, k: u32) -> Vec<u64> {
     match k {
       0 => vec![hash],
-      k if k < self.nside => {
+      k if k <= self.nside => {
         let HashParts { d0h, i, j } = self.decode_hash(hash);
         let capacity = {
           let k = k as usize;

--- a/src/nested/mod.rs
+++ b/src/nested/mod.rs
@@ -1617,7 +1617,7 @@ impl Layer {
     result_map
   }
 
-  /// Returns the hash values of the cells which are in the internal border of a square of
+  /// Returns the hash values of the cells which are on the internal border of a square of
   /// size `(1 + 2k) x (1 + 2k)` cells around the given cell.
   /// The regular `neighbours` methods correspond to `k=1`.
   ///

--- a/src/nested/mod.rs
+++ b/src/nested/mod.rs
@@ -1637,7 +1637,7 @@ impl Layer {
       k if k < self.nside => {
         let HashParts { d0h, i, j } = self.decode_hash(hash);
         let mut result = Vec::with_capacity(((k << 1) as usize) << 2);
-        self.neighbours_in_kth_ring_internal(d0h, i, j, k, result);
+        self.neighbours_in_kth_ring_internal(d0h, i, j, k, &mut result);
         result
       }
       _ => panic!(
@@ -1677,8 +1677,10 @@ impl Layer {
         let mut result = Vec::with_capacity(capacity);
         result.push(hash);
         for r in 1..(k + 1) {
-          self.neighbours_in_kth_ring_internal(d0h, i, j, r, result);
+          self.neighbours_in_kth_ring_internal(d0h, i, j, r, &mut result);
         }
+
+        result
       }
       _ => panic!(
         "The 'k' parameter is too large. Expected: <{}. Actual: {}.",
@@ -1717,6 +1719,10 @@ impl Layer {
         result.push(self.build_hash_from_parts(d0h, x, yfrom));
       }
     } else {
+      let k = k as i32;
+      let i = i as i32;
+      let j = j as i32;
+
       let xfrom = i - k;
       let xto = i + k;
       let yfrom = j - k;
@@ -1805,7 +1811,7 @@ impl Layer {
           .to_neighbour_base_cell_coo(d0h, i, j, SE)
           .map(|(d0h, i, j)| partial_compute(nside, d0h, i, j, k, &mut result));
       }
-      partial_compute(nside, d0h, i, j, k, &mut result);
+      partial_compute(nside, d0h, i, j, k, result);
     }
   }
 

--- a/src/nested/mod.rs
+++ b/src/nested/mod.rs
@@ -1619,7 +1619,11 @@ impl Layer {
 
   /// Returns the hash values of the cells which are on the internal border of a square of
   /// size `(1 + 2k) x (1 + 2k)` cells around the given cell.
-  /// The regular `neighbours` methods correspond to `k=1`.
+  ///
+  /// If that square does not cross base cells the result will contain `(1 + 2k) × (1 + 2k)` cells,
+  /// if it does there will be fewer cells.
+  ///
+  /// The regular `neighbours` methods correspond to `k=1`, `k=0` returns the input cell.
   ///
   /// # Panics
   /// * if `k` is larger than or equals to `nside`.


### PR DESCRIPTION
- [x] towards #13
- [x] extends 6c83b905efecf7503acde405c5c4b279d6846a11

I've tried wrapping the four loops from 6c83b905efecf7503acde405c5c4b279d6846a11 in a loop around rings, which mostly gives me the same results as my own implementation (minus the ordering within a ring, which I don't care about).

If this is something you'd be fine with merging, I'll need some help with updating the test.

I'm mostly python-based, so I wrote a [wrapper package](https://github.com/keewis/healpix-geo) that allows me to compare results (I do plan on submitting that code to `cds-healpix-python`, but for now the separate package allows me to iterate faster). In the future, that package will be used for geo-specific extensions of healpix, like mapping ellipsoidal coordinates onto an authalic sphere, and to allow me to test new functions a bit faster.